### PR TITLE
Remove constant Deprecate warning on Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   - gem update --system
   - gem update bundler
@@ -6,7 +7,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - jruby-19mode

--- a/commander.gemspec
+++ b/commander.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency('rubocop', '~> 0.41.1')
     s.add_development_dependency('json', '< 2.0')
   else
-    s.add_development_dependency('rubocop', '~> 0.46')
+    s.add_development_dependency('rubocop', '~> 0.49.1')
   end
 end

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -324,7 +324,7 @@ module Commander
     # Implements ask_for_CLASS methods.
 
     module AskForClass
-      DEPRECATED_CONSTANTS = [:Config, :TimeoutError, :MissingSourceFile, :NIL, :TRUE, :FALSE, :Fixnum, :Bignum].freeze
+      DEPRECATED_CONSTANTS = [:Config, :TimeoutError, :MissingSourceFile, :NIL, :TRUE, :FALSE, :Fixnum, :Bignum, :Data].freeze
       # All special cases in HighLine::Question#convert, except those that implement #parse
       (
         [Float, Integer, String, Symbol, Regexp, Array, File, Pathname] +

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.4.5'.freeze
+  VERSION = '4.4.6'.freeze
 end

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -6,8 +6,49 @@ describe Commander::Methods do
     expect(subject.ancestors).to include(Commander::UI)
   end
 
-  it 'includes Commander::UI::AskForClass' do
-    expect(subject.ancestors).to include(Commander::UI::AskForClass)
+  describe 'AskForClass' do
+    it 'includes Commander::UI::AskForClass' do
+      expect(subject.ancestors).to include(Commander::UI::AskForClass)
+    end
+
+    describe 'defining methods' do
+      let(:terminal) { double }
+
+      before do
+        allow(terminal).to receive(:ask)
+        $_old_terminal = $terminal
+        $terminal = terminal
+      end
+
+      after do
+        $terminal = $_old_terminal
+      end
+
+      subject do
+        Class.new do
+          include Commander::UI::AskForClass
+        end.new
+      end
+
+      it 'defines common "ask_for_*" methods' do
+        expect(subject.respond_to?(:ask_for_float)).to be_truthy
+      end
+
+      it 'responds to "ask_for_*" methods for classes that implement #parse' do
+        expect(subject.respond_to?(:ask_for_datetime)).to be_truthy
+      end
+
+      it 'fails "ask_for_*" method invocations without a prompt' do
+        expect do
+          subject.ask_for_datetime
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'implements "ask_for_*"' do
+        expect(terminal).to receive(:ask)
+        subject.ask_for_datetime('hi')
+      end
+    end
   end
 
   it 'includes Commander::Delegates' do


### PR DESCRIPTION
<img width="1488" alt="screen shot 2018-02-14 at 16 37 42" src="https://user-images.githubusercontent.com/147051/36192617-ab49bbfe-11a5-11e8-8478-07a0a8ba06b2.png">

I ran rubocop for fastlane main repo on Ruby 2.5. However, warnings are raised from this gem.

This is a forked version of commander-rb. So, I cherry-picked patches from the original repo.

https://github.com/commander-rb/commander/pull/62
https://github.com/commander-rb/commander/pull/63